### PR TITLE
[DO-304] output 참조 오류 수정

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,11 @@
 output "id" {
-  value = try(coalesce(aws_elasticache_replication_group.this[0].id, aws_elasticache_cluster.this[0].id), "")
+  value = try(aws_elasticache_replication_group.this[0].id, aws_elasticache_cluster.this[0].id)
 }
 
 output "name" {
-  value = try(coalesce(aws_elasticache_replication_group.this[0].replication_group_id, aws_elasticache_cluster.this[0].cluster_id), "")
+  value = try(aws_elasticache_replication_group.this[0].id, aws_elasticache_cluster.this[0].id)
 }
 
 output "primary_endpoint" {
-  value = try(coalesce(aws_elasticache_replication_group.this[0].primary_endpoint_address, aws_elasticache_cluster.this[0].cache_nodes[0].address), "")
+  value = try(aws_elasticache_replication_group.this[0].primary_endpoint_address, aws_elasticache_cluster.this[0].cache_nodes[0].address)
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,7 @@ output "id" {
 }
 
 output "name" {
-  value = try(aws_elasticache_replication_group.this[0].id, aws_elasticache_cluster.this[0].id)
+  value = try(aws_elasticache_replication_group.this[0].replication_group_id, aws_elasticache_cluster.this[0].id)
 }
 
 output "primary_endpoint" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,7 @@ output "id" {
 }
 
 output "name" {
-  value = try(aws_elasticache_replication_group.this[0].replication_group_id, aws_elasticache_cluster.this[0].id)
+  value = try(aws_elasticache_replication_group.this[0].replication_group_id, aws_elasticache_cluster.this[0].cluster_id)
 }
 
 output "primary_endpoint" {


### PR DESCRIPTION
`aws_elasticache_replication_group` 를 생성하지 않을 경우 참조 시 에러가 발생해 output에서 무조건 빈 문자열을 return 하는 오류 수정

* resource를 생성하였는데 id가 존재하지 않는 경우는 없으므로 `coalesce` 문을 사용하지 않아도 됨